### PR TITLE
Remove user from jwt in favor of user id, return user as separate field

### DIFF
--- a/init
+++ b/init
@@ -5,7 +5,6 @@
 # This script is following Google Shell Style standard
 # https://google.github.io/styleguide/shell.xml
 
-echo "sintiernt"
 # STDERR log function
 err() {
   echo -e "\n[$(date +'%Y-%m-%dT%H:%M:%S%z')]: $@\n" >&2

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -15,7 +15,8 @@ export class AuthService {
   async createToken(user: User) {
     return {
       expiresIn: this.configService.get('JWT_EXPIRATION_TIME'),
-      accessToken: this.jwtService.sign(Object.assign({}, user)),
+      accessToken: this.jwtService.sign({id: user.id}),
+      user: user
     };
   }
 

--- a/src/modules/auth/jwt.strategy.ts
+++ b/src/modules/auth/jwt.strategy.ts
@@ -17,13 +17,13 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  async validate({ iat, exp, email }: JwtPayload, done) {
+  async validate({ iat, exp, id }: JwtPayload, done) {
     const timeDiff = exp - iat;
     if (timeDiff <= 0) {
       throw new UnauthorizedException();
     }
 
-    const user = await this.usersService.getByEmail(email);
+    const user = await this.usersService.get(id);
     if (!user) {
       throw new UnauthorizedException();
     }


### PR DESCRIPTION
Problem: If User model grows, it can cause problems when serializing User in jwt.
Solution: JWT contains only userId, and user is sent as separate field in login/register response