### PR TITLE
Fix dockerfile for prod with yarn --prod=true

### DIFF
--- a/Dockerfile-prod
+++ b/Dockerfile-prod
@@ -6,7 +6,7 @@ ENV NODE_ENV production
 COPY package.json yarn.lock ./
 
 # install dev dependencies too
-RUN set -x && yarn --prod=false
+RUN set -x && yarn --prod=true
 
 COPY . .
 RUN set -x && yarn run prestart:prod


### PR DESCRIPTION
Within the file `Dockerfile-prod` yarn was installed with:
```
yarn --prod=false
```
Which would unnecessarily add the dev dependencies to the package.

PS. There's no real need for `=true` but I've chosen to be explicit instead of implicit for better readability.